### PR TITLE
fix: clarify types of `guardedArrayIncludes()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Does the exact same thing as `Array.isArray()` but derives the type `unknown[]` 
 
 #### `guardedArrayIncludes(collection, searchElement)`
 
-Type-narrowing variant of `Array.prototype.includes` that works on any iterable. Returns `true` if `searchElement` is strictly equal to a member of `collection`. When `true`, narrows the type of `searchElement` to the element type of the iterable (`C extends Iterable<infer U> ? U : never`). Useful when you have an `unknown` (or union) value and want to both test membership and refine its type in one step.
+Type-narrowing variant of `Array.prototype.includes` that works on arrays and sets. Returns `true` if `searchElement` is strictly equal to a member of `collection`. When `true`, narrows the type of `searchElement` to the element type of the iterable (`C extends Iterable<infer U> ? U : never`). Useful when you have an `unknown` (or union) value and want to both test membership and refine its type in one step.
 
 Example:
 ```js

--- a/lib/array.js
+++ b/lib/array.js
@@ -81,13 +81,19 @@ export function isStringArray (value) {
 }
 
 /**
- * @template {Iterable<unknown>} C
+ * @template {Set<unknown> | Array<unknown> | ReadonlyArray<unknown>} C
  * @param {C} collection
  * @param {unknown} searchElement
  * @returns {searchElement is (C extends Iterable<infer U> ? U : never)}
  */
 export function guardedArrayIncludes (collection, searchElement) {
-  return collection instanceof Set
-    ? collection.has(searchElement)
-    : Array.prototype.includes.call(collection, searchElement);
+  if (typesafeIsArray(collection)) {
+    return collection.includes(searchElement);
+  }
+
+  if (!(collection instanceof Set)) {
+    throw new TypeError('Invalid collection type');
+  }
+
+  return collection.has(searchElement);
 }

--- a/test-d/guarded-array-includes.test-d.ts
+++ b/test-d/guarded-array-includes.test-d.ts
@@ -1,0 +1,46 @@
+import { expectType, expectNotType } from 'tsd';
+
+import { guardedArrayIncludes } from '../lib/array.js';
+
+// Array narrowing
+const values: (string | number)[] = ['a', 1, 'b'];
+const searchValues: unknown = 'a';
+if (guardedArrayIncludes(values, searchValues)) {
+  expectType<string | number>(searchValues);
+  // Inside branch we only know that 'a' is an element; param doesn't narrow array itself
+  expectType<(string | number)[]>(values);
+} else {
+  expectNotType<(string | number)[]>(searchValues);
+  expectType<unknown>(searchValues);
+}
+
+// Set narrowing
+const set: Set<string | number> = new Set(['x', 2]);
+const searchSet: unknown = 'x';
+if (guardedArrayIncludes(set, searchSet)) {
+  expectType<string | number>(searchSet);
+  expectType<Set<string | number>>(set);
+}
+
+// Union of Set and Array still usable
+const union = Math.random() > 0.5 ? [5] : new Set(['z']);
+const searchUnion: unknown = 'z';
+if (guardedArrayIncludes(union, searchUnion)) {
+  expectType<string | number>(searchUnion);
+  expectType<number[] | Set<string>>(union);
+}
+
+// Narrowing of searched value against number[]
+const onlyNumbers: number[] = [1, 2, 3];
+const unknownSearch: unknown = 2;
+if (guardedArrayIncludes(onlyNumbers, unknownSearch)) {
+  expectType<number>(unknownSearch);
+}
+
+// Works with readonly array
+const readonlyArray: readonly ['foo', 'bar'] = ['foo', 'bar'];
+const searchReadonly: unknown = 'foo';
+if (guardedArrayIncludes(readonlyArray, searchReadonly)) {
+  expectType<'foo' | 'bar'>(searchReadonly);
+  expectType<readonly ['foo', 'bar']>(readonlyArray);
+}

--- a/test/guarded-array-includes.spec.js
+++ b/test/guarded-array-includes.spec.js
@@ -1,0 +1,85 @@
+import chai from 'chai';
+
+import { guardedArrayIncludes } from '../lib/array.js';
+import { FrozenSet } from '../lib/set.js';
+
+function * sampleGen () { yield 1; yield 2; }
+
+const should = chai.should();
+
+describe('guardedArrayIncludes()', () => {
+  it('should work on a basic array', () => {
+    const arr = [1, 2, 3];
+    guardedArrayIncludes(arr, 2).should.equal(true);
+    guardedArrayIncludes(arr, 4).should.equal(false);
+  });
+
+  it('should work on a readonly (const) array / tuple', () => {
+    const tuple = /** @type {const} */ (['a', 'b', 'c']);
+    guardedArrayIncludes(tuple, 'a').should.equal(true);
+    guardedArrayIncludes(tuple, 'd').should.equal(false);
+  });
+
+  it('should work on a Set', () => {
+    const set = new Set(['x', 'y']);
+    guardedArrayIncludes(set, 'x').should.equal(true);
+    guardedArrayIncludes(set, 'z').should.equal(false);
+  });
+
+  it('should work on a FrozenSet', () => {
+    const set = new FrozenSet(['alpha', 'beta']);
+    guardedArrayIncludes(set, 'alpha').should.equal(true);
+    guardedArrayIncludes(set, 'gamma').should.equal(false);
+  });
+
+  it('should work on a Set of objects (identity semantics)', () => {
+    const foo = { foo: true };
+    const bar = { bar: true };
+    const set = new Set([foo]);
+    guardedArrayIncludes(set, foo).should.equal(true);
+    guardedArrayIncludes(set, bar).should.equal(false);
+  });
+
+  describe('unsupported', () => {
+    it('should throw on unsupported string collection', () => {
+      should.Throw(() => {
+        // @ts-expect-error unsupported string collection
+        guardedArrayIncludes('abc', 10);
+      }, TypeError, 'Invalid collection type');
+    });
+
+    it('should throw on unsupported typed array', () => {
+      const ta = new Uint8Array([5, 10, 15]);
+
+      should.Throw(() => {
+        // @ts-expect-error unsupported typed array
+        guardedArrayIncludes(ta, 10);
+      }, TypeError, 'Invalid collection type');
+    });
+
+    it('should throw on arguments object', () => {
+      should.Throw(function () {
+        // @ts-expect-error "arguments" are currently unsupported
+        guardedArrayIncludes(arguments, 2);
+      }, TypeError, 'Invalid collection type');
+    });
+
+    it('should throw on Map (unsupported collection type)', () => {
+      const map = new Map([['a', 1]]);
+
+      should.Throw(() => {
+        // @ts-expect-error unsupported collection type
+        guardedArrayIncludes(map, 10);
+      }, TypeError, 'Invalid collection type');
+    });
+
+    it('should throw on generic iterable (generator)', () => {
+      const iterable = sampleGen();
+
+      should.Throw(() => {
+        // @ts-expect-error unsupported collection type
+        guardedArrayIncludes(iterable, 10);
+      }, TypeError, 'Invalid collection type');
+    });
+  });
+});


### PR DESCRIPTION
This pull request refactors the `guardedArrayIncludes` utility to restrict its usage to arrays (including readonly arrays) and sets, improving type safety and error handling. It also adds comprehensive unit and type tests to verify correct behavior and error cases.

### API restriction and error handling

* Refactored `guardedArrayIncludes` in `lib/array.js` to only accept arrays (including readonly arrays) and sets, throwing a `TypeError` for unsupported collection types such as strings, typed arrays, arguments objects, Maps, and generic iterables.

### Documentation update

* Updated the `README.md` to clarify that `guardedArrayIncludes` now works only with arrays and sets, not all iterables.

### Testing improvements

* Added new unit tests in `test/guarded-array-includes.spec.js` to cover valid cases (arrays, readonly arrays, sets, FrozenSet) and to assert that unsupported types throw errors.
* Added type-level tests in `test-d/guarded-array-includes.test-d.ts` to verify correct type narrowing for arrays, sets, unions, and readonly arrays.