### PR TITLE
fix(types): improve types for `typedObjectKeys*`

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -36,16 +36,16 @@ export function pick (input, keys) {
 }
 
 /**
- * @template {{ [key: string]: unknown }} T
+ * @template {{}} T
  * @param {T} value
  * @returns {Array<keyof T>}
  */
 export function typedObjectKeys (value) {
-  return Object.keys(value);
+  return /** @type {Array<keyof T>} */ (Object.keys(value));
 }
 
 /**
- * @template {{ [key: string]: unknown }} T
+ * @template {{}} T
  * @param {T} value
  * @returns {Array<T extends unknown ? keyof T : never>}
  */

--- a/test-d/object/keys.test-d.ts
+++ b/test-d/object/keys.test-d.ts
@@ -13,3 +13,28 @@ expectType<string[]>(typedObjectKeys(genericObject));
 expectType<Array<'foo' | 'bar'>>(typedObjectKeys(basicObject));
 expectType<Array<'foo' | 'bar' | 'xyz'>>(typedObjectKeysAll(unionObject));
 expectType<string[]>(typedObjectKeysAll(genericObject));
+
+// Readonly (const) object
+const readonlyConst = { alpha: 1, beta: 2 } as const;
+expectType<Array<'alpha' | 'beta'>>(typedObjectKeys(readonlyConst));
+expectType<Array<'alpha' | 'beta'>>(typedObjectKeysAll(readonlyConst));
+
+// Object with optional property
+const optionalObject = {} as { foo: number; bar?: string };
+expectType<Array<'foo' | 'bar'>>(typedObjectKeys(optionalObject));
+expectType<Array<'foo' | 'bar'>>(typedObjectKeysAll(optionalObject));
+
+// Union involving optional property (tests intersection vs union of all keys)
+const optionalUnion = {} as ({ foo?: 1; bar: 2 } | { bar: 2; baz: 3 });
+expectType<Array<'bar'>>(typedObjectKeys(optionalUnion));
+expectType<Array<'foo' | 'bar' | 'baz'>>(typedObjectKeysAll(optionalUnion));
+
+// Union with generic-like record
+const genericUnion = {} as ({ a: number; b: number } | Record<string, number>);
+expectType<Array<'a' | 'b'>>(typedObjectKeys(genericUnion));
+expectType<string[]>(typedObjectKeysAll(genericUnion));
+
+// Any object
+const anyObj: any = { x: 1 };
+expectType<Array<string | number | symbol>>(typedObjectKeys(anyObj));
+expectType<Array<string | number | symbol>>(typedObjectKeysAll(anyObj));


### PR DESCRIPTION
This pull request improves the type definitions and type tests for the `typedObjectKeys` and `typedObjectKeysAll` utility functions. The main focus is on making the type inference more robust and verifying correct behavior for a variety of object shapes, including readonly objects, objects with optional properties, unions, and generic records.

Type definition improvements:

* Updated the JSDoc template type for `typedObjectKeys` and related functions in `lib/object.js` to use a more general type parameter (`{{}} T`) and added a type assertion to ensure the return type is correctly inferred as `Array<keyof T>`.

Expanded type test coverage:

* Added new test cases in `test-d/object/keys.test-d.ts` to verify correct type inference for readonly (const) objects, objects with optional properties, unions involving optional properties, unions with generic-like records, and objects of type `any`. These tests ensure that `typedObjectKeys` and `typedObjectKeysAll` handle all these scenarios as expected.