### PR TITLE
feat: add `assertStringKeyedObject`

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Asserts that `value` is an array where every element is of the given `type` (str
 
 Asserts that `obj` is an object where all values are of the given `type` and all keys are strings. This is useful for validating objects used as dictionaries/maps with homogeneous value types.
 
+#### `assertStringKeyedObject(obj)`
+
+Asserts that `obj` is an object with only string keys. Throws an error if `obj` is not an object or if any of its keys are not strings. Useful for validating that an object can be used as a string-keyed dictionary.
+
 ### `is`-calls / Type Checks
 
 #### `isObjectWithKey(obj, key)`

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -45,6 +45,20 @@ export function assertObject (obj) {
 }
 
 /**
+ * @param {unknown} obj
+ * @returns {asserts obj is Record<string, unknown>}
+ */
+export function assertStringKeyedObject (obj) {
+  assertObject(obj);
+
+  assertArrayOfLiteralType(
+    Object.keys(obj),
+    'string',
+    'Expected object keys to be string, but got:'
+  );
+}
+
+/**
  * @template {string} K
  * @param {unknown} obj
  * @param {K} key
@@ -128,17 +142,11 @@ export function assertArrayOfLiteralType (value, type, message) {
  * @returns {asserts obj is Record<string, LiteralTypes[T]>}
  */
 export function assertObjectValueType (obj, type) {
-  assertObject(obj);
+  assertStringKeyedObject(obj);
 
   assertArrayOfLiteralType(
     Object.values(obj),
     type,
     `Expected object values to have type "${type}", but got:`
-  );
-
-  assertArrayOfLiteralType(
-    Object.keys(obj),
-    'string',
-    'Expected object keys to be string, but got:'
   );
 }

--- a/test-d/assert.test-d.ts
+++ b/test-d/assert.test-d.ts
@@ -6,6 +6,7 @@ import {
   assertObjectValueType,
   assertObjectWithKey,
   assertOptionalKeyWithType,
+  assertStringKeyedObject,
   assertType,
 } from '../lib/assert.js';
 
@@ -192,4 +193,18 @@ try {
   const unknownValue9: unknown = { x: 1, y: 2 };
   assertObjectValueType(unknownValue9, 'number');
   expectType<Record<string, number>>(unknownValue9);
+} catch {}
+
+// assertStringKeyedObject - narrows unknown to Record<string, unknown>
+try {
+  const unknownValue10: unknown = { foo: 'bar', num: 123 };
+  assertStringKeyedObject(unknownValue10);
+  expectType<Record<string, unknown>>(unknownValue10);
+} catch {}
+
+// assertStringKeyedObject - with known object still gives Record<string, unknown>
+try {
+  const knownObject = { foo: 'bar', num: 123 } as const;
+  assertStringKeyedObject(knownObject);
+  expectType<{ readonly foo: 'bar'; readonly num: 123; }>(knownObject);
 } catch {}

--- a/test/assert.spec.js
+++ b/test/assert.spec.js
@@ -10,6 +10,7 @@ import {
   assertObjectWithKey,
   assertKeyWithType,
   assertOptionalKeyWithType,
+  assertStringKeyedObject,
   assertType,
   TypeHelpersAssertionError,
 } from '../lib/assert.js';
@@ -46,7 +47,6 @@ describe('assert', () => {
     it('should not throw for valid objects', () => {
       expect(() => assertObject({})).to.not.throw();
       expect(() => assertObject({ foo: 'bar' })).to.not.throw();
-      expect(() => assertObject([])).to.not.throw();
     });
 
     it('should throw for non-objects', () => {
@@ -54,6 +54,7 @@ describe('assert', () => {
       expect(() => assertObject(undefined)).to.throw(TypeHelpersAssertionError);
       expect(() => assertObject('string')).to.throw(TypeHelpersAssertionError);
       expect(() => assertObject(123)).to.throw(TypeHelpersAssertionError);
+      expect(() => assertObject([])).to.throw(TypeHelpersAssertionError);
     });
   });
 
@@ -184,6 +185,27 @@ describe('assert', () => {
     it('should validate that all keys are strings', () => {
       const obj = { a: 'foo', b: 'bar' };
       expect(() => assertObjectValueType(obj, 'string')).to.not.throw();
+    });
+  });
+
+  describe('assertStringKeyedObject()', () => {
+    it('should not throw for objects with string keys', () => {
+      expect(() => assertStringKeyedObject({})).to.not.throw();
+      expect(() => assertStringKeyedObject({ foo: 'bar' })).to.not.throw();
+      expect(() => assertStringKeyedObject({ a: 1, b: 2, c: 3 })).to.not.throw();
+      expect(() => assertStringKeyedObject({ nested: { key: 'value' } })).to.not.throw();
+    });
+
+    it('should not throw for empty objects', () => {
+      expect(() => assertStringKeyedObject({})).to.not.throw();
+    });
+
+    it('should throw when value is not an object', () => {
+      expect(() => assertStringKeyedObject(null)).to.throw(TypeHelpersAssertionError, 'Expected an object');
+      expect(() => assertStringKeyedObject(undefined)).to.throw(TypeHelpersAssertionError, 'Expected an object');
+      expect(() => assertStringKeyedObject('string')).to.throw(TypeHelpersAssertionError, 'Expected an object');
+      expect(() => assertStringKeyedObject(123)).to.throw(TypeHelpersAssertionError, 'Expected an object');
+      expect(() => assertStringKeyedObject([])).to.throw(TypeHelpersAssertionError, 'Expected an object');
     });
   });
 });


### PR DESCRIPTION
Ensure `assertObject` does not accept arrays and introduce `assertStringKeyedObject` to validate objects with string keys. Update tests to cover new functionality and edge cases.