### PR TITLE
chore: update TSTyche to v6.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "clean": "run-p clean:*",
     "prepack": "run-s build",
     "prepare": "husky",
-    "test:tstyche": "run-s build && tstyche --target \"$(jq -r '.engines.typescript' package.json)\" --reporters ./node_modules/@voxpelli/tstyche-reporters/lib/tstyche-dot-reporter.js,summary && run-s clean",
+    "test:tstyche": "run-s build && tstyche --target \"$(jq -r '.engines.typescript' package.json)\" --reporters dot,summary && run-s clean",
     "test:mocha": "c8 --reporter=lcov --reporter text mocha 'test/**/*.spec.js'",
     "test-ci": "run-s test:mocha",
     "test": "run-s check test:*"
@@ -70,7 +70,7 @@
     "knip": "^5.82.1",
     "mocha": "^11.7.5",
     "npm-run-all2": "^8.0.4",
-    "tstyche": "^6.1.0",
+    "tstyche": "^6.2.0",
     "type-coverage": "^2.29.7",
     "typescript": "~5.9.3",
     "validate-conventional-commit": "^1.0.4"


### PR DESCRIPTION
This PR updates TSTyche to v6.2.0 which ships with a new built-in `dot` reporter.

Thanks again for the idea! It was fun to come back to TSTyche reporters. I didn’t touch the output implementation for some time. That was a nice opportunity to look through the code.

---

Differently from `@voxpelli/tstyche-reporters`, the built-in `dot` reporter prints a dot per file. Although the first implementation was printing a dot per `test()`. I was adding tests for each `:error` event and realised that in some cases there is an error reported with no dots in the output. That felt strange.

Unlike JavaScript test runners, TSTyche does not require `test()`. It is because a file that compiles is a valid type of test (e.g. it can be tested against several versions of TS). This is why I decided to print a dot per file instead.

By the way, formatted errors are included at the end of the run.

---

One more detail, I have added the `--verbose` flag. It works nicely with the default reporter, which shows the structure only in single-file runs. With the `--verbose` flag, the structure is always printed out for all the files.

Try it out, please. Not sure, but it might be that is roughly what you found missing.

The `markdown` reporter will be added a bit later. I have to research and think a bit about it.