### PR TITLE
feat: support arrays of types in many type checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ Asserts that `obj` is an object and contains the property `key`. Throws an error
 
 Asserts that `value` is of the given `type` (string literal, eg. `'string'`, `'number'`, `'array'`, `'null'` – same as returned by [`explainVariable()`](#explainvariablevalue)). Throws an error if not. Optional custom error message.
 
+Supports union types by passing an array of type names:
+
+```javascript
+assertType(value, ['string', 'number']); // narrows to string | number
+assertType(value, ['string', 'boolean', 'null']); // narrows to string | boolean | null
+```
+
 #### `assertKeyWithType(obj, key, type)`
 
 Asserts that `obj` is an object, contains the property `key`, and that `obj[key]` is of the given `type`.
@@ -115,9 +122,22 @@ Asserts that `obj` is an object and either does not contain the property `key`, 
 
 Asserts that `value` is an array where every element is of the given `type` (string literal, eg. `'string'`, `'number'`, `'array'`, `'null'`). Throws an error if any element fails the type check. Optional custom error message.
 
+Supports union types by passing an array of type names:
+
+```javascript
+assertArrayOfLiteralType(value, ['string', 'number']); // narrows to Array<string | number>
+```
+
 #### `assertObjectValueType(obj, type)`
 
 Asserts that `obj` is an object where all values are of the given `type` and all keys are strings. This is useful for validating objects used as dictionaries/maps with homogeneous value types.
+
+Supports union types by passing an array of type names:
+
+```javascript
+assertObjectValueType(obj, 'string'); // narrows to Record<string, string>
+assertObjectValueType(obj, ['string', 'number', 'boolean']); // narrows to Record<string, string | number | boolean>
+```
 
 ### `is`-calls / Type Checks
 
@@ -128,6 +148,14 @@ Returns `true` if `obj` is an object and contains the property `key`.
 #### `isType(value, type)`
 
 Returns `true` if `value` is of the given `type` (string literal, eg. `'string'`, `'number'`, `'array'`, `'null'` – same as returned by [`explainVariable()`](#explainvariablevalue)).
+
+Supports union types by passing an array of type names:
+
+```javascript
+if (isType(value, ['string', 'number'])) {
+  // value is narrowed to string | number
+}
+```
 
 #### `isKeyWithType(obj, key, type)`
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -61,14 +61,16 @@ export function assertObjectWithKey (obj, key) {
 /**
  * @template {keyof LiteralTypes} T
  * @param {unknown} value
- * @param {T} type
+ * @param {T | T[]} type
  * @param {string} [message]
  * @returns {asserts value is LiteralTypes[T]}
  */
 export function assertType (value, type, message) {
+  const types = typesafeIsArray(type) ? type : [type];
+
   assert(
     isType(value, type),
-    (message || `Expected type "${type}", but got:`) + ' ' + explainVariable(value)
+    (message || `Expected type "${types.join('", "')}", but got:`) + ' ' + explainVariable(value)
   );
 }
 
@@ -111,7 +113,7 @@ export function assertOptionalKeyWithType (obj, key, type) {
 /**
  * @template {keyof LiteralTypes} T
  * @param {unknown} value
- * @param {T} type
+ * @param {T | T[]} type
  * @param {string} [message]
  * @returns {asserts value is Array<LiteralTypes[T]>}
  */
@@ -124,16 +126,18 @@ export function assertArrayOfLiteralType (value, type, message) {
 /**
  * @template {keyof LiteralTypes} T
  * @param {unknown} obj
- * @param {T} type
+ * @param {T | T[]} type
  * @returns {asserts obj is Record<string, LiteralTypes[T]>}
  */
 export function assertObjectValueType (obj, type) {
   assertObject(obj);
 
+  const types = typesafeIsArray(type) ? type : [type];
+
   assertArrayOfLiteralType(
     Object.values(obj),
     type,
-    `Expected object values to have type "${type}", but got:`
+    `Expected object values to have type "${types.join('", "')}", but got:`
   );
 
   assertArrayOfLiteralType(

--- a/lib/is.js
+++ b/lib/is.js
@@ -1,3 +1,5 @@
+import { typesafeIsArray } from './array.js';
+
 /** @import { LiteralTypes } from './types/literal-types.d.ts' */
 
 /**
@@ -13,14 +15,18 @@ export function isObjectWithKey (obj, key) {
 /**
  * @template {keyof LiteralTypes} T
  * @param {unknown} value
- * @param {T} type
+ * @param {T | T[]} type
  * @returns {value is LiteralTypes[T]}
  */
 export function isType (value, type) {
-  if (value === null) return type === 'null';
-  if (Array.isArray(value)) return type === 'array';
-  // eslint-disable-next-line valid-typeof
-  return (typeof value) === type;
+  const types = typesafeIsArray(type) ? type : [type];
+
+  return types.some((t) => {
+    if (value === null) return t === 'null';
+    if (Array.isArray(value)) return t === 'array';
+    // eslint-disable-next-line valid-typeof
+    return (typeof value) === t;
+  });
 }
 
 /**

--- a/test/assert.spec.js
+++ b/test/assert.spec.js
@@ -158,6 +158,27 @@ describe('assert', () => {
     });
   });
 
+  describe('assertArrayOfLiteralType() with array of types', () => {
+    it('should not throw for arrays with elements matching any allowed type', () => {
+      expect(() => assertArrayOfLiteralType(['foo', 123, 'bar'], ['string', 'number'])).to.not.throw();
+      expect(() => assertArrayOfLiteralType([1, 'two', 3], ['string', 'number'])).to.not.throw();
+      expect(() => assertArrayOfLiteralType([true, 42, 'test'], ['boolean', 'number', 'string'])).to.not.throw();
+    });
+
+    it('should not throw for empty arrays with array of types', () => {
+      expect(() => assertArrayOfLiteralType([], ['string', 'number'])).to.not.throw();
+    });
+
+    it('should throw when array contains element not matching any allowed type', () => {
+      expect(() => assertArrayOfLiteralType(['foo', null], ['string', 'number'])).to.throw(TypeHelpersAssertionError, 'Expected type "string", "number"');
+      expect(() => assertArrayOfLiteralType([1, undefined], ['string', 'boolean'])).to.throw(TypeHelpersAssertionError);
+    });
+
+    it('should work with custom error message and array of types', () => {
+      expect(() => assertArrayOfLiteralType(['foo', null], ['string', 'number'], 'Custom message')).to.throw(TypeHelpersAssertionError, 'Custom message');
+    });
+  });
+
   describe('assertObjectValueType()', () => {
     it('should not throw for objects with all values of correct type', () => {
       expect(() => assertObjectValueType({ a: 'foo', b: 'bar' }, 'string')).to.not.throw();
@@ -184,6 +205,21 @@ describe('assert', () => {
     it('should validate that all keys are strings', () => {
       const obj = { a: 'foo', b: 'bar' };
       expect(() => assertObjectValueType(obj, 'string')).to.not.throw();
+    });
+
+    it('should not throw for objects with values of any allowed type (array)', () => {
+      expect(() => assertObjectValueType({ a: 'foo', b: 123, c: true }, ['string', 'number', 'boolean'])).to.not.throw();
+      expect(() => assertObjectValueType({ x: 1, y: 'two' }, ['string', 'number'])).to.not.throw();
+      expect(() => assertObjectValueType({ flag: true, count: 42 }, ['boolean', 'number'])).to.not.throw();
+    });
+
+    it('should not throw for empty objects with array of types', () => {
+      expect(() => assertObjectValueType({}, ['string', 'number'])).to.not.throw();
+    });
+
+    it('should throw when object contains value not matching any allowed type', () => {
+      expect(() => assertObjectValueType({ a: 'foo', b: null }, ['string', 'number'])).to.throw(TypeHelpersAssertionError, 'Expected object values to have type "string", "number"');
+      expect(() => assertObjectValueType({ x: 1, y: undefined }, ['string', 'boolean'])).to.throw(TypeHelpersAssertionError, 'Expected object values to have type "string", "boolean"');
     });
   });
 });

--- a/test/literal-types.spec.js
+++ b/test/literal-types.spec.js
@@ -82,6 +82,38 @@ describe('Literal Types', () => {
     });
   });
 
+  describe('isType with array of types', () => {
+    it('should return true for values matching any allowed type', () => {
+      expect(isType('hello', ['string', 'number'])).to.equal(true);
+      expect(isType(42, ['string', 'number'])).to.equal(true);
+      expect(isType(true, ['boolean', 'number'])).to.equal(true);
+      expect(isType([], ['array', 'object'])).to.equal(true);
+    });
+
+    it('should return false for values matching none of the allowed types', () => {
+      expect(isType(true, ['string', 'number'])).to.equal(false);
+      expect(isType('hello', ['number', 'boolean'])).to.equal(false);
+      // eslint-disable-next-line unicorn/no-null
+      expect(isType(null, ['string', 'number', 'boolean'])).to.equal(false);
+    });
+
+    it('should work with single-element array', () => {
+      expect(isType('hello', ['string'])).to.equal(true);
+      expect(isType(42, ['string'])).to.equal(false);
+    });
+
+    it('should handle empty array (always returns false)', () => {
+      expect(isType('hello', [])).to.equal(false);
+      expect(isType(42, [])).to.equal(false);
+      expect(isType(true, [])).to.equal(false);
+    });
+
+    it('should work with all literal types in array', () => {
+      expect(isType('test', ['string', 'number', 'boolean', 'null', 'undefined', 'array', 'object', 'function', 'symbol', 'bigint'])).to.equal(true);
+      expect(isType(42, ['string', 'number', 'boolean'])).to.equal(true);
+    });
+  });
+
   describe('assertType', () => {
     it('passes for matching type - string', () => {
       const value = 'hello';
@@ -151,6 +183,55 @@ describe('Literal Types', () => {
       expect(() => assertType(0, 'number')).to.not.throw();
       expect(() => assertType('', 'string')).to.not.throw();
       expect(() => assertType(false, 'boolean')).to.not.throw();
+    });
+  });
+
+  describe('assertType with array of types', () => {
+    it('should not throw for values matching any allowed type', () => {
+      expect(() => assertType('hello', ['string', 'number'])).to.not.throw();
+      expect(() => assertType(42, ['string', 'number'])).to.not.throw();
+      expect(() => assertType(true, ['boolean', 'number'])).to.not.throw();
+      expect(() => assertType([], ['array', 'object'])).to.not.throw();
+    });
+
+    it('should throw when value matches none of the allowed types', () => {
+      expect(() => assertType(true, ['string', 'number'])).to.throw(TypeHelpersAssertionError);
+      expect(() => assertType('hello', ['number', 'boolean'])).to.throw(TypeHelpersAssertionError);
+    });
+
+    it('should throw with error message including all types', () => {
+      try {
+        assertType(true, ['string', 'number']);
+        expect.fail('Should have thrown');
+      } catch (err) {
+        expect(err).to.be.instanceOf(TypeHelpersAssertionError);
+        if (err instanceof TypeHelpersAssertionError) {
+          expect(err.message).to.include('string');
+          expect(err.message).to.include('number');
+        }
+      }
+    });
+
+    it('should work with single-element array', () => {
+      expect(() => assertType('hello', ['string'])).to.not.throw();
+      expect(() => assertType(42, ['string'])).to.throw(TypeHelpersAssertionError);
+    });
+
+    it('should handle empty array (always throws)', () => {
+      expect(() => assertType('hello', [])).to.throw(TypeHelpersAssertionError);
+      expect(() => assertType(42, [])).to.throw(TypeHelpersAssertionError);
+    });
+
+    it('should work with custom error message', () => {
+      try {
+        assertType(true, ['string', 'number'], 'Custom error');
+        expect.fail('Should have thrown');
+      } catch (err) {
+        expect(err).to.be.instanceOf(TypeHelpersAssertionError);
+        if (err instanceof TypeHelpersAssertionError) {
+          expect(err.message).to.include('Custom error');
+        }
+      }
     });
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,7 @@
   ],
   "include": [
     "lib/**/*",
-    "test/**/*",
-    "typetests/**/*"
+    "test/**/*"
   ],
   "compilerOptions": {
     "lib": ["es2022", "dom"],

--- a/typetests/assert.test.ts
+++ b/typetests/assert.test.ts
@@ -25,6 +25,49 @@ describe('assertType', () => {
   });
 });
 
+describe('assertType with array of types', () => {
+  it('should narrow unknown to union type', () => {
+    const unknownValue: unknown = 'test';
+
+    assertType(unknownValue, ['string', 'number']);
+    expect(unknownValue).type.toBe<string | number>();
+  });
+
+  it('should narrow unknown to multiple type union', () => {
+    const unknownValue: unknown = true;
+
+    assertType(unknownValue, ['string', 'number', 'boolean']);
+    expect(unknownValue).type.toBe<string | number | boolean>();
+  });
+
+  it('should work with single-element array', () => {
+    const unknownValue: unknown = 'test';
+
+    assertType(unknownValue, ['string']);
+    expect(unknownValue).type.toBe<string>();
+  });
+
+  it('should work with regular array of types', () => {
+    const unknownValue: unknown = 42;
+    const types: ('string' | 'number')[] = ['string', 'number'];
+
+    assertType(unknownValue, types);
+    expect(unknownValue).type.toBe<string | number>();
+  });
+
+  it('should raise error for invalid type literal', () => {
+    const unknownValue: unknown = 'test';
+
+    expect(assertType(unknownValue, 'invalid')).type.toRaiseError();
+  });
+
+  it('should raise error for array with invalid type literal', () => {
+    const unknownValue: unknown = 42;
+
+    expect(assertType(unknownValue, ['string', 'invalid'])).type.toRaiseError();
+  });
+});
+
 describe('assertObjectWithKey', () => {
   it('should narrow unknown object with specific key', () => {
     const unknownValue: unknown = {};
@@ -85,6 +128,42 @@ describe('assertArrayOfLiteralType', () => {
   });
 });
 
+describe('assertArrayOfLiteralType with array of types', () => {
+  it('should narrow unknown to union array', () => {
+    const unknownValue: unknown = ['foo', 123, 'bar'];
+
+    assertArrayOfLiteralType(unknownValue, ['string', 'number']);
+    expect(unknownValue).type.toBe<Array<string | number>>();
+  });
+
+  it('should narrow unknown to multiple type union array', () => {
+    const unknownValue: unknown = [true, 42, 'test'];
+
+    assertArrayOfLiteralType(unknownValue, ['boolean', 'number', 'string']);
+    expect(unknownValue).type.toBe<Array<boolean | number | string>>();
+  });
+
+  it('should work with regular array of types', () => {
+    const unknownValue: unknown = [1, 'two'];
+    const types: ('string' | 'number')[] = ['string', 'number'];
+
+    assertArrayOfLiteralType(unknownValue, types);
+    expect(unknownValue).type.toBe<Array<string | number>>();
+  });
+
+  it('should raise error for invalid type literal', () => {
+    const unknownValue: unknown = ['foo', 'bar'];
+
+    expect(assertArrayOfLiteralType(unknownValue, 'invalid')).type.toRaiseError();
+  });
+
+  it('should raise error for array with invalid type literal', () => {
+    const unknownValue: unknown = ['test'];
+
+    expect(assertArrayOfLiteralType(unknownValue, ['string', 'notAType'])).type.toRaiseError();
+  });
+});
+
 describe('assertObjectValueType', () => {
   it('should narrow unknown to string record', () => {
     const unknownValue8: unknown = { a: 'foo', b: 'bar' };
@@ -98,5 +177,39 @@ describe('assertObjectValueType', () => {
 
     assertObjectValueType(unknownValue9, 'number');
     expect(unknownValue9).type.toBe<Record<string, number>>();
+  });
+
+  it('should narrow unknown to union type record with array of types', () => {
+    const unknownValue10: unknown = { a: 'foo', b: 123, c: true };
+
+    assertObjectValueType(unknownValue10, ['string', 'number', 'boolean']);
+    expect(unknownValue10).type.toBe<Record<string, string | number | boolean>>();
+  });
+
+  it('should narrow unknown to string or number record', () => {
+    const unknownValue11: unknown = { x: 1, y: 'two' };
+
+    assertObjectValueType(unknownValue11, ['string', 'number']);
+    expect(unknownValue11).type.toBe<Record<string, string | number>>();
+  });
+
+  it('should work with regular array of types', () => {
+    const unknownValue12: unknown = { a: true, b: false };
+    const types: ('boolean' | 'number')[] = ['boolean', 'number'];
+
+    assertObjectValueType(unknownValue12, types);
+    expect(unknownValue12).type.toBe<Record<string, boolean | number>>();
+  });
+
+  it('should raise error for invalid type literal', () => {
+    const unknownValue: unknown = { a: 'foo' };
+
+    expect(assertObjectValueType(unknownValue, 'invalid')).type.toRaiseError();
+  });
+
+  it('should raise error for array with invalid type literal', () => {
+    const unknownValue: unknown = { x: 1, y: 2 };
+
+    expect(assertObjectValueType(unknownValue, ['number', 'invalid'])).type.toRaiseError();
   });
 });

--- a/typetests/is.test.ts
+++ b/typetests/is.test.ts
@@ -25,6 +25,53 @@ describe('isType', () => {
   });
 });
 
+describe('isType with array of types', () => {
+  it('should narrow unknown to union type', () => {
+    const unknownValue: unknown = 'test';
+
+    if (isType(unknownValue, ['string', 'number'])) {
+      expect(unknownValue).type.toBe<string | number>();
+    }
+  });
+
+  it('should narrow unknown to multiple type union', () => {
+    const unknownValue: unknown = true;
+
+    if (isType(unknownValue, ['string', 'number', 'boolean'])) {
+      expect(unknownValue).type.toBe<string | number | boolean>();
+    }
+  });
+
+  it('should work with single-element array', () => {
+    const unknownValue: unknown = 'test';
+
+    if (isType(unknownValue, ['string'])) {
+      expect(unknownValue).type.toBe<string>();
+    }
+  });
+
+  it('should work with regular array of types', () => {
+    const unknownValue: unknown = 42;
+    const types: ('string' | 'number')[] = ['string', 'number'];
+
+    if (isType(unknownValue, types)) {
+      expect(unknownValue).type.toBe<string | number>();
+    }
+  });
+
+  it('should raise error for invalid type literal', () => {
+    const unknownValue: unknown = 'test';
+
+    expect(isType(unknownValue, 'invalid')).type.toRaiseError();
+  });
+
+  it('should raise error for array with invalid type literal', () => {
+    const unknownValue: unknown = 42;
+
+    expect(isType(unknownValue, ['string', 'invalid'])).type.toRaiseError();
+  });
+});
+
 describe('isObjectWithKey', () => {
   it('should narrow unknown object with specific key', () => {
     const unknownValue: unknown = {};


### PR DESCRIPTION
This pull request adds support for union types to the `assertType`, `assertArrayOfLiteralType`, `assertObjectValueType`, and `isType` functions. Now, you can pass an array of type names to these functions to validate or narrow values to a union of types (e.g., `'string' | 'number'`). The documentation and tests have been updated to reflect and verify these enhancements.

**Core Functionality Enhancements:**

- Added support for union types in `assertType`, `assertArrayOfLiteralType`, `assertObjectValueType`, and `isType` by allowing an array of type names as the `type` parameter. This enables type assertions and checks against multiple types at once. [[1]](diffhunk://#diff-4354d778aaf56c7c9558812b2f108f001388ef2a6ae846dda4e08f16a5edb20fL64-R73) [[2]](diffhunk://#diff-4354d778aaf56c7c9558812b2f108f001388ef2a6ae846dda4e08f16a5edb20fL114-R116) [[3]](diffhunk://#diff-4354d778aaf56c7c9558812b2f108f001388ef2a6ae846dda4e08f16a5edb20fL127-R140) [[4]](diffhunk://#diff-74933e74c5729f3f41bd2a744ce0d77e4320409cb2cdc00a7cd4c7db0e21b1dbR1-R2) [[5]](diffhunk://#diff-74933e74c5729f3f41bd2a744ce0d77e4320409cb2cdc00a7cd4c7db0e21b1dbL16-R29)
- Updated error messages in these functions to include all expected types when union types are used, improving debugging clarity. [[1]](diffhunk://#diff-4354d778aaf56c7c9558812b2f108f001388ef2a6ae846dda4e08f16a5edb20fL64-R73) [[2]](diffhunk://#diff-4354d778aaf56c7c9558812b2f108f001388ef2a6ae846dda4e08f16a5edb20fL127-R140)

**Documentation Updates:**

- Expanded the `README.md` documentation to explain and provide examples for union type support in `assertType`, `assertArrayOfLiteralType`, `assertObjectValueType`, and `isType`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R106-R112) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R125-R141) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R152-R159)

**Testing Improvements:**

- Added comprehensive unit tests for union type support in `assertType`, `assertArrayOfLiteralType`, `assertObjectValueType`, and `isType` in both JavaScript (`test/`) and TypeScript (`typetests/`) test suites, ensuring correct runtime behavior and type narrowing. [[1]](diffhunk://#diff-86444a810ebb1587c6f65a92e0b3b704146c2ba32bb60de285230402571d14ccR161-R181) [[2]](diffhunk://#diff-86444a810ebb1587c6f65a92e0b3b704146c2ba32bb60de285230402571d14ccR209-R223) [[3]](diffhunk://#diff-53654a84195f41f0881b8b13fe8e2e01cc6e455578f2b418cc2e7c39f258c5feR85-R116) [[4]](diffhunk://#diff-53654a84195f41f0881b8b13fe8e2e01cc6e455578f2b418cc2e7c39f258c5feR189-R237) [[5]](diffhunk://#diff-df7b2ad0f9131505923fa6b8bd1f6daf8d2e126ea98e6f7bb101e400d678fb65R28-R70) [[6]](diffhunk://#diff-df7b2ad0f9131505923fa6b8bd1f6daf8d2e126ea98e6f7bb101e400d678fb65R131-R166) [[7]](diffhunk://#diff-df7b2ad0f9131505923fa6b8bd1f6daf8d2e126ea98e6f7bb101e400d678fb65R181-R214) [[8]](diffhunk://#diff-cf899b1c26328f7282db4946b87c94c9ef1421904ebf4ab89971aad593e555e2R28-R74)