### PR TITLE
fix: remove TypeScript peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,14 +48,6 @@
     "test-ci": "run-s test:mocha",
     "test": "run-s check test:*"
   },
-  "peerDependencies": {
-    "typescript": ">=5.8.0"
-  },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.10",


### PR DESCRIPTION
This pull request makes a small change to the `package.json` file by removing the `peerDependencies` and `peerDependenciesMeta` sections related to `typescript`. This simplifies the dependency management and removes the optional peer dependency on TypeScript.