### PR TITLE
feat: allow array of types in `*KeyWithType`

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -158,16 +158,18 @@ export function assertType (value, type, message) {
  * @template {keyof LiteralTypes} T
  * @param {unknown} obj
  * @param {K} key
- * @param {T} type
+ * @param {T | T[]} type
  * @returns {asserts obj is Record<K, LiteralTypes[T]>}
  */
 export function assertKeyWithType (obj, key, type) {
   assertObjectWithKey(obj, key);
 
+  const types = typesafeIsArray(type) ? type : [type];
+
   assertType(
     obj[key],
-    type,
-    `Expected key "${key}" to have type "${type}", but got:`
+    types,
+    `Expected key "${key}" to have type "${types.join('", "')}", but got:`
   );
 }
 
@@ -176,7 +178,7 @@ export function assertKeyWithType (obj, key, type) {
  * @template {keyof LiteralTypes} T
  * @param {unknown} obj
  * @param {K} key
- * @param {T} type
+ * @param {T | T[]} type
  * @returns {asserts obj is Partial<Record<K, LiteralTypes[T]>>}
  */
 export function assertOptionalKeyWithType (obj, key, type) {
@@ -185,7 +187,8 @@ export function assertOptionalKeyWithType (obj, key, type) {
   if (!isOptionalKeyWithType(obj, key, type)) {
     assertObjectWithKey(obj, key);
 
-    throw new TypeHelpersAssertionError(`Expected existing key "${key}" to be undefined or have type "${type}", but got: ${explainVariable(obj[key])}`);
+    const types = typesafeIsArray(type) ? type : [type];
+    throw new TypeHelpersAssertionError(`Expected existing key "${key}" to be undefined or have type "${types.join('", "')}", but got: ${explainVariable(obj[key])}`);
   }
 }
 

--- a/lib/is.js
+++ b/lib/is.js
@@ -42,7 +42,7 @@ export function isType (value, type) {
  * @template {keyof LiteralTypes} T
  * @param {unknown} obj
  * @param {K} key
- * @param {T} type
+ * @param {T | T[]} type
  * @returns {obj is Record<K, LiteralTypes[T]>}
  */
 export function isKeyWithType (obj, key, type) {
@@ -57,7 +57,7 @@ export function isKeyWithType (obj, key, type) {
  * @template {keyof LiteralTypes} T
  * @param {unknown} obj
  * @param {K} key
- * @param {T} type
+ * @param {T | T[]} type
  * @returns {obj is Partial<Record<K, LiteralTypes[T]>>}
  */
 export function isOptionalKeyWithType (obj, key, type) {

--- a/test/assert.spec.js
+++ b/test/assert.spec.js
@@ -297,4 +297,81 @@ describe('assert', () => {
       expect(() => assertObjectValueType({ x: 1, y: undefined }, ['string', 'boolean'])).to.throw(TypeHelpersAssertionError, 'Expected object values to have type "string", "boolean"');
     });
   });
+
+  describe('assertKeyWithType() with array of types', () => {
+    it('should not throw when value matches any allowed type', () => {
+      expect(() => assertKeyWithType({ x: 'hello' }, 'x', ['string', 'number'])).to.not.throw();
+      expect(() => assertKeyWithType({ x: 42 }, 'x', ['string', 'number'])).to.not.throw();
+      expect(() => assertKeyWithType({ x: true }, 'x', ['boolean', 'number'])).to.not.throw();
+    });
+
+    it('should throw when value matches none of the allowed types', () => {
+      expect(() => assertKeyWithType({ x: true }, 'x', ['string', 'number'])).to.throw(TypeHelpersAssertionError, 'Expected key "x" to have type "string", "number"');
+      expect(() => assertKeyWithType({ x: 'hello' }, 'x', ['number', 'boolean'])).to.throw(TypeHelpersAssertionError, 'Expected key "x" to have type "number", "boolean"');
+    });
+
+    it('should throw when key does not exist', () => {
+      expect(() => assertKeyWithType({ y: 'hello' }, 'x', ['string', 'number'])).to.throw(TypeHelpersAssertionError, 'Expected key "x" to exist in object');
+    });
+
+    it('should throw when object is not an object', () => {
+      expect(() => assertKeyWithType(undefined, 'x', ['string', 'number'])).to.throw(TypeHelpersAssertionError, 'Expected an object');
+      expect(() => assertKeyWithType('not an object', 'x', ['string', 'number'])).to.throw(TypeHelpersAssertionError, 'Expected an object');
+    });
+
+    it('should work with single-element array', () => {
+      expect(() => assertKeyWithType({ x: 'hello' }, 'x', ['string'])).to.not.throw();
+      expect(() => assertKeyWithType({ x: 42 }, 'x', ['string'])).to.throw(TypeHelpersAssertionError, 'Expected key "x" to have type "string"');
+    });
+
+    // eslint-disable-next-line unicorn/no-null
+    it('should work with null as an allowed type', () => {
+      // eslint-disable-next-line unicorn/no-null
+      expect(() => assertKeyWithType({ x: null }, 'x', ['string', 'null'])).to.not.throw();
+      expect(() => assertKeyWithType({ x: 'hello' }, 'x', ['string', 'null'])).to.not.throw();
+      // eslint-disable-next-line unicorn/no-null
+      expect(() => assertKeyWithType({ x: null }, 'x', ['number', 'boolean'])).to.throw(TypeHelpersAssertionError, 'Expected key "x" to have type "number", "boolean"');
+    });
+  });
+
+  describe('assertOptionalKeyWithType() with array of types', () => {
+    it('should not throw when key is absent', () => {
+      expect(() => assertOptionalKeyWithType({ y: 'other' }, 'x', ['string', 'number'])).to.not.throw();
+    });
+
+    it('should not throw when key exists with value matching any allowed type', () => {
+      expect(() => assertOptionalKeyWithType({ x: 'hello' }, 'x', ['string', 'number'])).to.not.throw();
+      expect(() => assertOptionalKeyWithType({ x: 42 }, 'x', ['string', 'number'])).to.not.throw();
+    });
+
+    it('should not throw when key exists and is undefined', () => {
+      expect(() => assertOptionalKeyWithType({ x: undefined }, 'x', ['string', 'number'])).to.not.throw();
+    });
+
+    it('should throw when key exists with value matching none of the allowed types', () => {
+      expect(() => assertOptionalKeyWithType({ x: true }, 'x', ['string', 'number'])).to.throw(TypeHelpersAssertionError, 'Expected existing key "x" to be undefined or have type "string", "number"');
+      expect(() => assertOptionalKeyWithType({ x: Symbol('sym') }, 'x', ['string', 'boolean'])).to.throw(TypeHelpersAssertionError, 'Expected existing key "x" to be undefined or have type "string", "boolean"');
+    });
+
+    it('should throw when object is not an object', () => {
+      expect(() => assertOptionalKeyWithType(undefined, 'x', ['string', 'number'])).to.throw(TypeHelpersAssertionError, 'Expected an object');
+      expect(() => assertOptionalKeyWithType('not an object', 'x', ['string', 'number'])).to.throw(TypeHelpersAssertionError, 'Expected an object');
+    });
+
+    it('should work with single-element array', () => {
+      expect(() => assertOptionalKeyWithType({ x: 'hello' }, 'x', ['string'])).to.not.throw();
+      expect(() => assertOptionalKeyWithType({ y: 'other' }, 'x', ['string'])).to.not.throw();
+      expect(() => assertOptionalKeyWithType({ x: 42 }, 'x', ['string'])).to.throw(TypeHelpersAssertionError, 'Expected existing key "x" to be undefined or have type "string"');
+    });
+
+    // eslint-disable-next-line unicorn/no-null
+    it('should work with null as an allowed type', () => {
+      // eslint-disable-next-line unicorn/no-null
+      expect(() => assertOptionalKeyWithType({ x: null }, 'x', ['string', 'null'])).to.not.throw();
+      expect(() => assertOptionalKeyWithType({ x: 'hello' }, 'x', ['string', 'null'])).to.not.throw();
+      expect(() => assertOptionalKeyWithType({ y: 'other' }, 'x', ['string', 'null'])).to.not.throw();
+      // eslint-disable-next-line unicorn/no-null
+      expect(() => assertOptionalKeyWithType({ x: null }, 'x', ['number', 'boolean'])).to.throw(TypeHelpersAssertionError, 'Expected existing key "x" to be undefined or have type "number", "boolean"');
+    });
+  });
 });

--- a/test/is.spec.js
+++ b/test/is.spec.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'mocha';
 import chai from 'chai';
 
-import { isKeyWithValue } from '../lib/is.js';
+import { isKeyWithValue, isKeyWithType, isOptionalKeyWithType } from '../lib/is.js';
 
 const { expect } = chai;
 
@@ -18,6 +18,83 @@ describe('is', () => {
 
     it('should return false when key exists but has wrong value', () => {
       expect(isKeyWithValue({ foo: 'bar' }, 'foo', 'baz')).to.equal(false);
+    });
+  });
+
+  describe('isKeyWithType() with array of types', () => {
+    it('should return true when value matches any allowed type', () => {
+      expect(isKeyWithType({ x: 'hello' }, 'x', ['string', 'number'])).to.equal(true);
+      expect(isKeyWithType({ x: 42 }, 'x', ['string', 'number'])).to.equal(true);
+      expect(isKeyWithType({ x: true }, 'x', ['boolean', 'number'])).to.equal(true);
+    });
+
+    it('should return false when value matches none of the allowed types', () => {
+      expect(isKeyWithType({ x: true }, 'x', ['string', 'number'])).to.equal(false);
+      expect(isKeyWithType({ x: 'hello' }, 'x', ['number', 'boolean'])).to.equal(false);
+    });
+
+    it('should work with single-element array', () => {
+      expect(isKeyWithType({ x: 'hello' }, 'x', ['string'])).to.equal(true);
+      expect(isKeyWithType({ x: 42 }, 'x', ['string'])).to.equal(false);
+    });
+
+    it('should return false for key not in object', () => {
+      expect(isKeyWithType({ x: 'hello' }, 'y', ['string', 'number'])).to.equal(false);
+    });
+
+    it('should return false when object is not an object', () => {
+      expect(isKeyWithType(undefined, 'x', ['string', 'number'])).to.equal(false);
+      expect(isKeyWithType('not an object', 'x', ['string', 'number'])).to.equal(false);
+    });
+
+    // eslint-disable-next-line unicorn/no-null
+    it('should work with null as an allowed type', () => {
+      // eslint-disable-next-line unicorn/no-null
+      expect(isKeyWithType({ x: null }, 'x', ['string', 'null'])).to.equal(true);
+      // eslint-disable-next-line unicorn/no-null
+      expect(isKeyWithType({ x: null }, 'x', ['number', 'boolean'])).to.equal(false);
+      expect(isKeyWithType({ x: 'hello' }, 'x', ['string', 'null'])).to.equal(true);
+    });
+  });
+
+  describe('isOptionalKeyWithType() with array of types', () => {
+    it('should return true when key is absent', () => {
+      expect(isOptionalKeyWithType({ y: 'other' }, 'x', ['string', 'number'])).to.equal(true);
+    });
+
+    it('should return true when key exists with value matching any allowed type', () => {
+      expect(isOptionalKeyWithType({ x: 'hello' }, 'x', ['string', 'number'])).to.equal(true);
+      expect(isOptionalKeyWithType({ x: 42 }, 'x', ['string', 'number'])).to.equal(true);
+    });
+
+    it('should return true when key exists and is undefined', () => {
+      expect(isOptionalKeyWithType({ x: undefined }, 'x', ['string', 'number'])).to.equal(true);
+    });
+
+    it('should return false when key exists with value matching none of the allowed types', () => {
+      expect(isOptionalKeyWithType({ x: true }, 'x', ['string', 'number'])).to.equal(false);
+      expect(isOptionalKeyWithType({ x: Symbol('sym') }, 'x', ['string', 'boolean'])).to.equal(false);
+    });
+
+    it('should return false when object is not an object', () => {
+      expect(isOptionalKeyWithType(undefined, 'x', ['string', 'number'])).to.equal(false);
+      expect(isOptionalKeyWithType('not an object', 'x', ['string', 'number'])).to.equal(false);
+    });
+
+    it('should work with single-element array', () => {
+      expect(isOptionalKeyWithType({ x: 'hello' }, 'x', ['string'])).to.equal(true);
+      expect(isOptionalKeyWithType({ y: 'other' }, 'x', ['string'])).to.equal(true);
+      expect(isOptionalKeyWithType({ x: 42 }, 'x', ['string'])).to.equal(false);
+    });
+
+    // eslint-disable-next-line unicorn/no-null
+    it('should work with null as an allowed type', () => {
+      // eslint-disable-next-line unicorn/no-null
+      expect(isOptionalKeyWithType({ x: null }, 'x', ['string', 'null'])).to.equal(true);
+      // eslint-disable-next-line unicorn/no-null
+      expect(isOptionalKeyWithType({ x: null }, 'x', ['number', 'boolean'])).to.equal(false);
+      expect(isOptionalKeyWithType({ x: 'hello' }, 'x', ['string', 'null'])).to.equal(true);
+      expect(isOptionalKeyWithType({ y: 'other' }, 'x', ['string', 'null'])).to.equal(true);
     });
   });
 });

--- a/typetests/assert.test.ts
+++ b/typetests/assert.test.ts
@@ -133,6 +133,49 @@ describe('assertKeyWithType', () => {
   });
 });
 
+describe('assertKeyWithType with array of types', () => {
+  it('should narrow to union type', () => {
+    const unknownValue: unknown = { x: 'test' };
+
+    assertKeyWithType(unknownValue, 'x', ['string', 'number']);
+    expect(unknownValue).type.toBe<Record<'x', string | number>>();
+  });
+
+  it('should narrow unknown to multiple type union', () => {
+    const unknownValue: unknown = { x: true };
+
+    assertKeyWithType(unknownValue, 'x', ['string', 'number', 'boolean']);
+    expect(unknownValue).type.toBe<Record<'x', string | number | boolean>>();
+  });
+
+  it('should work with single-element array', () => {
+    const unknownValue: unknown = { x: 'test' };
+
+    assertKeyWithType(unknownValue, 'x', ['string']);
+    expect(unknownValue).type.toBe<Record<'x', string>>();
+  });
+
+  it('should work with regular array of types', () => {
+    const unknownValue: unknown = { x: 42 };
+    const types: ('string' | 'number')[] = ['string', 'number'];
+
+    assertKeyWithType(unknownValue, 'x', types);
+    expect(unknownValue).type.toBe<Record<'x', string | number>>();
+  });
+
+  it('should raise error for invalid type literal', () => {
+    const unknownValue: unknown = { x: 'test' };
+
+    expect(assertKeyWithType(unknownValue, 'x', 'invalid')).type.toRaiseError();
+  });
+
+  it('should raise error for array with invalid type literal', () => {
+    const unknownValue: unknown = { x: 42 };
+
+    expect(assertKeyWithType(unknownValue, 'x', ['string', 'invalid'])).type.toRaiseError();
+  });
+});
+
 describe('assertKeyWithValue', () => {
   it('should narrow unknown object with key and widened string value for inline string literals', () => {
     const unknownValue: unknown = {};
@@ -181,6 +224,58 @@ describe('assertOptionalKeyWithType', () => {
 
     assertOptionalKeyWithType(objWithoutKey, 'foo', 'string');
     expect(objWithoutKey).type.toBe<{ bar: boolean } & Partial<Record<'foo', string>>>();
+  });
+});
+
+describe('assertOptionalKeyWithType with array of types', () => {
+  it('should narrow to union type', () => {
+    const unknownValue: unknown = { x: 'test' };
+
+    assertOptionalKeyWithType(unknownValue, 'x', ['string', 'number']);
+    expect(unknownValue).type.toBe<Partial<Record<'x', string | number>>>();
+  });
+
+  it('should narrow unknown to multiple type union', () => {
+    const unknownValue: unknown = { x: true };
+
+    assertOptionalKeyWithType(unknownValue, 'x', ['string', 'number', 'boolean']);
+    expect(unknownValue).type.toBe<Partial<Record<'x', string | number | boolean>>>();
+  });
+
+  it('should work with single-element array', () => {
+    const unknownValue: unknown = { x: 'test' };
+
+    assertOptionalKeyWithType(unknownValue, 'x', ['string']);
+    expect(unknownValue).type.toBe<Partial<Record<'x', string>>>();
+  });
+
+  it('should work with regular array of types', () => {
+    const unknownValue: unknown = { x: 42 };
+    const types: ('string' | 'number')[] = ['string', 'number'];
+
+    assertOptionalKeyWithType(unknownValue, 'x', types);
+    expect(unknownValue).type.toBe<Partial<Record<'x', string | number>>>();
+  });
+
+  it('should raise error for invalid type literal', () => {
+    const unknownValue: unknown = { x: 'test' };
+
+    expect(assertOptionalKeyWithType(unknownValue, 'x', 'invalid')).type.toRaiseError();
+  });
+
+  it('should raise error for array with invalid type literal', () => {
+    const unknownValue: unknown = { x: 42 };
+
+    expect(assertOptionalKeyWithType(unknownValue, 'x', ['string', 'invalid'])).type.toRaiseError();
+  });
+
+  it('should work with null as an allowed type', () => {
+    // eslint-disable-next-line unicorn/no-null
+    const unknownValue: unknown = { x: null };
+
+    // eslint-disable-next-line unicorn/no-null
+    assertOptionalKeyWithType(unknownValue, 'x', ['string', 'null']);
+    expect(unknownValue).type.toBe<Partial<Record<'x', string | null>>>();
   });
 });
 

--- a/typetests/is.test.ts
+++ b/typetests/is.test.ts
@@ -105,6 +105,53 @@ describe('isKeyWithType', () => {
   });
 });
 
+describe('isKeyWithType with array of types', () => {
+  it('should narrow to union type', () => {
+    const unknownValue: unknown = { x: 'test' };
+
+    if (isKeyWithType(unknownValue, 'x', ['string', 'number'])) {
+      expect(unknownValue).type.toBe<Record<'x', string | number>>();
+    }
+  });
+
+  it('should narrow unknown to multiple type union', () => {
+    const unknownValue: unknown = { x: true };
+
+    if (isKeyWithType(unknownValue, 'x', ['string', 'number', 'boolean'])) {
+      expect(unknownValue).type.toBe<Record<'x', string | number | boolean>>();
+    }
+  });
+
+  it('should work with single-element array', () => {
+    const unknownValue: unknown = { x: 'test' };
+
+    if (isKeyWithType(unknownValue, 'x', ['string'])) {
+      expect(unknownValue).type.toBe<Record<'x', string>>();
+    }
+  });
+
+  it('should work with regular array of types', () => {
+    const unknownValue: unknown = { x: 42 };
+    const types: ('string' | 'number')[] = ['string', 'number'];
+
+    if (isKeyWithType(unknownValue, 'x', types)) {
+      expect(unknownValue).type.toBe<Record<'x', string | number>>();
+    }
+  });
+
+  it('should raise error for invalid type literal', () => {
+    const unknownValue: unknown = { x: 'test' };
+
+    expect(isKeyWithType(unknownValue, 'x', 'invalid')).type.toRaiseError();
+  });
+
+  it('should raise error for array with invalid type literal', () => {
+    const unknownValue: unknown = { x: 42 };
+
+    expect(isKeyWithType(unknownValue, 'x', ['string', 'invalid'])).type.toRaiseError();
+  });
+});
+
 describe('isKeyWithValue', () => {
   it('should narrow unknown object with key and widened string value for inline string literals', () => {
     const unknownValue: unknown = {};
@@ -166,6 +213,63 @@ describe('isOptionalKeyWithType', () => {
 
     if (isOptionalKeyWithType(objWithUndefined, 'foo', 'string')) {
       expect(objWithUndefined).type.toBe<{ bar: boolean; foo: undefined; } & Partial<Record<'foo', string>>>();
+    }
+  });
+});
+
+describe('isOptionalKeyWithType with array of types', () => {
+  it('should narrow to union type', () => {
+    const unknownValue: unknown = { x: 'test' };
+
+    if (isOptionalKeyWithType(unknownValue, 'x', ['string', 'number'])) {
+      expect(unknownValue).type.toBe<Partial<Record<'x', string | number>>>();
+    }
+  });
+
+  it('should narrow unknown to multiple type union', () => {
+    const unknownValue: unknown = { x: true };
+
+    if (isOptionalKeyWithType(unknownValue, 'x', ['string', 'number', 'boolean'])) {
+      expect(unknownValue).type.toBe<Partial<Record<'x', string | number | boolean>>>();
+    }
+  });
+
+  it('should work with single-element array', () => {
+    const unknownValue: unknown = { x: 'test' };
+
+    if (isOptionalKeyWithType(unknownValue, 'x', ['string'])) {
+      expect(unknownValue).type.toBe<Partial<Record<'x', string>>>();
+    }
+  });
+
+  it('should work with regular array of types', () => {
+    const unknownValue: unknown = { x: 42 };
+    const types: ('string' | 'number')[] = ['string', 'number'];
+
+    if (isOptionalKeyWithType(unknownValue, 'x', types)) {
+      expect(unknownValue).type.toBe<Partial<Record<'x', string | number>>>();
+    }
+  });
+
+  it('should raise error for invalid type literal', () => {
+    const unknownValue: unknown = { x: 'test' };
+
+    expect(isOptionalKeyWithType(unknownValue, 'x', 'invalid')).type.toRaiseError();
+  });
+
+  it('should raise error for array with invalid type literal', () => {
+    const unknownValue: unknown = { x: 42 };
+
+    expect(isOptionalKeyWithType(unknownValue, 'x', ['string', 'invalid'])).type.toRaiseError();
+  });
+
+  it('should work with null as an allowed type', () => {
+    // eslint-disable-next-line unicorn/no-null
+    const unknownValue: unknown = { x: null };
+
+    // eslint-disable-next-line unicorn/no-null
+    if (isOptionalKeyWithType(unknownValue, 'x', ['string', 'null'])) {
+      expect(unknownValue).type.toBe<Partial<Record<'x', string | null>>>();
     }
   });
 });


### PR DESCRIPTION
Enhance the `isKeyWithType` and `assertKeyWithType` functions to accept an array of types, allowing for more flexible type checking. Update tests to cover new functionality and ensure proper error handling for invalid types.